### PR TITLE
update path for web3 types as not to fail on consuming dapp

### DIFF
--- a/spec/computable/parameterizer/can-be-set.spec.ts
+++ b/spec/computable/parameterizer/can-be-set.spec.ts
@@ -1,6 +1,6 @@
 import * as ganache from 'ganache-cli'
 import Web3 from 'web3'
-import { EventEmitter, EventLog } from '../../../node_modules/web3/types.d'
+import { EventEmitter, EventLog } from 'web3/types.d'
 import { increaseTime } from '../../helpers'
 import { onData } from '../../../src/helpers'
 import Eip20 from '../../../src/contracts/eip-20'

--- a/spec/computable/parameterizer/challenge-can-be-resolved.spec.ts
+++ b/spec/computable/parameterizer/challenge-can-be-resolved.spec.ts
@@ -1,6 +1,6 @@
 import * as ganache from 'ganache-cli'
 import Web3 from 'web3'
-import { Contract } from '../../../node_modules/web3/types.d'
+import { Contract } from 'web3/types.d'
 import { increaseTime } from '../../helpers'
 import { onData } from '../../../src/helpers'
 import { deployDll, deployAttributeStore } from '../../../src/helpers'

--- a/spec/computable/parameterizer/challenge-reparam.spec.ts
+++ b/spec/computable/parameterizer/challenge-reparam.spec.ts
@@ -1,6 +1,6 @@
 import * as ganache from 'ganache-cli'
 import Web3 from 'web3'
-import { Contract } from '../../../node_modules/web3/types.d'
+import { Contract } from 'web3/types.d'
 import { increaseTime } from '../../helpers'
 import { ParameterDefaults } from '../../../src/constants'
 import Parameterizer from '../../../src/contracts/parameterizer'

--- a/spec/computable/parameterizer/parameterizer.spec.ts
+++ b/spec/computable/parameterizer/parameterizer.spec.ts
@@ -9,11 +9,10 @@ let server:any, provider:any, web3:Web3, accounts:string[], parameterizer:Parame
 // startup the test rpc making sure a websocket server is running
 beforeAll(() => {
   server = ganache.server({ws:true})
-  server.listen(8545)
-  server.on('close', () => console.log('stopped listening'))
+  server.listen(8445)
 
   // TODO use the web3 IProvider?
-  provider = new Web3.providers.WebsocketProvider('ws://localhost:8545')
+  provider = new Web3.providers.WebsocketProvider('ws://localhost:8445')
   web3 = new Web3(provider)
 })
 

--- a/spec/computable/registry/app-was-made.spec.ts
+++ b/spec/computable/registry/app-was-made.spec.ts
@@ -1,6 +1,6 @@
 import * as ganache from 'ganache-cli'
 import Web3 from 'web3'
-import { Contract } from '../../../node_modules/web3/types.d'
+import { Contract } from 'web3/types.d'
 import { deployDll, deployAttributeStore } from '../../../src/helpers'
 import { stringToBytes, increaseTime } from '../../helpers'
 import Eip20 from '../../../src/contracts/eip-20'

--- a/spec/computable/registry/apply.spec.ts
+++ b/spec/computable/registry/apply.spec.ts
@@ -1,6 +1,6 @@
 import * as ganache from 'ganache-cli'
 import Web3 from 'web3'
-import { Contract, Block } from '../../../node_modules/web3/types.d'
+import { Contract, Block } from 'web3/types.d'
 import { stringToBytes, increaseTime } from '../../helpers'
 import Eip20 from '../../../src/contracts/eip-20'
 import Voting from '../../../src/contracts/plcr-voting'

--- a/spec/computable/registry/challenge.spec.ts
+++ b/spec/computable/registry/challenge.spec.ts
@@ -1,6 +1,6 @@
 import * as ganache from 'ganache-cli'
 import Web3 from 'web3'
-import { Contract, Block } from '../../../node_modules/web3/types.d'
+import { Contract, Block } from 'web3/types.d'
 import { stringToBytes, increaseTime, whitelist } from '../../helpers'
 import Eip20 from '../../../src/contracts/eip-20'
 import Voting from '../../../src/contracts/plcr-voting'

--- a/spec/computable/registry/registry.spec.ts
+++ b/spec/computable/registry/registry.spec.ts
@@ -1,6 +1,6 @@
 import * as ganache from 'ganache-cli'
 import Web3 from 'web3'
-import { Contract } from '../../../node_modules/web3/types.d'
+import { Contract } from 'web3/types.d'
 import { NAME } from '../../../src/constants'
 import { deployDll, deployAttributeStore } from '../../../src/helpers'
 import Eip20 from '../../../src/contracts/eip-20'

--- a/spec/computable/voting/plcr-voting.spec.ts
+++ b/spec/computable/voting/plcr-voting.spec.ts
@@ -1,6 +1,6 @@
 import * as ganache from 'ganache-cli'
 import Web3 from 'web3'
-import { Contract } from '../../../node_modules/web3/types.d'
+import { Contract } from 'web3/types.d'
 import { ParameterDefaults, NAME } from '../../../src/constants'
 import { onData, deployDll, deployAttributeStore } from '../../../src/helpers'
 import { stringToBytes } from '../../helpers'

--- a/src/abstracts/deployable.ts
+++ b/src/abstracts/deployable.ts
@@ -1,5 +1,5 @@
 import Web3 from 'web3'
-import { Contract, EventEmitter } from '../../node_modules/web3/types.d'
+import { Contract, EventEmitter } from 'web3/types.d'
 import { Errors, GAS, GAS_PRICE } from '../constants'
 import {
   Keyed,

--- a/src/contracts/eip-20.ts
+++ b/src/contracts/eip-20.ts
@@ -1,4 +1,5 @@
 import Web3 from 'web3'
+import { Contract, TransactionReceipt } from 'web3/types.d'
 import {
   Keyed,
   ContractOptions,
@@ -7,7 +8,6 @@ import {
 } from '../interfaces'
 import Deployable from '../abstracts/deployable'
 import tokenJson from '../../computable/build/contracts/EIP20.json'
-import { Contract, TransactionReceipt } from '../../node_modules/web3/types.d'
 import { Nos } from '../types'
 import { Token, GAS, GAS_PRICE } from '../../src/constants'
 

--- a/src/contracts/parameterizer.ts
+++ b/src/contracts/parameterizer.ts
@@ -1,10 +1,10 @@
 import Web3 from 'web3'
+import { TransactionReceipt } from 'web3/types.d'
 import { ParameterDefaults, GAS, GAS_PRICE, Errors } from '../constants'
 import Deployable from '../abstracts/deployable'
 import { Nos } from '../types'
 import parameterizerJson from '../../computable/build/contracts/Parameterizer.json'
 // TODO PR web3 to export these properly
-import { TransactionReceipt } from '../../node_modules/web3/types.d'
 import {
   Keyed,
   ContractOptions,

--- a/src/contracts/plcr-voting.ts
+++ b/src/contracts/plcr-voting.ts
@@ -1,9 +1,9 @@
 import Web3 from 'web3'
+import { TransactionReceipt } from 'web3/types.d'
 import { GAS, GAS_PRICE, Errors } from '../../src/constants'
 import Deployable from '../abstracts/deployable'
 import { Nos } from '../types'
 import votingJson from '../../computable/build/contracts/PLCRVoting.json'
-import { TransactionReceipt } from '../../node_modules/web3/types.d'
 import { updateBytecode } from '../../src/helpers'
 import {
   Keyed,

--- a/src/contracts/registry.ts
+++ b/src/contracts/registry.ts
@@ -1,10 +1,10 @@
 import Web3 from 'web3'
+import { TransactionReceipt } from 'web3/types.d'
 import { GAS, GAS_PRICE, Errors } from '../constants'
 import Deployable from '../abstracts/deployable'
 import { Nos } from '../types'
 import registryJson from '../../computable/build/contracts/Registry.json'
 // TODO PR web3 to export these properly
-import { TransactionReceipt } from '../../node_modules/web3/types.d'
 import {
   Keyed,
   ContractOptions,

--- a/src/helpers/deploy.ts
+++ b/src/helpers/deploy.ts
@@ -1,5 +1,5 @@
 import Web3 from 'web3'
-import { Contract } from '../../node_modules/web3/types.d'
+import { Contract } from 'web3/types.d'
 import dllJson from '../../computable/build/contracts/DLL.json'
 import storeJson from '../../computable/build/contracts/AttributeStore.json'
 import {

--- a/src/helpers/event.ts
+++ b/src/helpers/event.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, EventLog } from '../../node_modules/web3/types.d'
+import { EventEmitter, EventLog } from 'web3/types.d'
 /**
  * The callback-based Event Emitter system exposed in Web3's `.on` paradigm
  * can be 'promisified' via this helper so that you can use async/await with it.

--- a/src/helpers/receipt.ts
+++ b/src/helpers/receipt.ts
@@ -3,7 +3,7 @@
  * objects that are returned from any-and-all contract class transactions
  */
 
-import { TransactionReceipt } from '../../node_modules/web3/types.d'
+import { TransactionReceipt } from 'web3/types.d'
 
 /**
  * Access the data held in receipt.events.name.returnValues.

--- a/src/interfaces/contract.ts
+++ b/src/interfaces/contract.ts
@@ -1,5 +1,5 @@
+import { BlockType } from 'web3/types.d'
 import { Nos } from '../types'
-import { BlockType } from '../../node_modules/web3/types.d'
 
 /**
  * Contracts have some repeatedly used options which may, or may not be passed


### PR DESCRIPTION
part one of a few parter where i update the paths throught the modules

next i'm going to use a new TS feature that lets us name paths like `@src/interfaces/...` vs relative ones