### PR TITLE
Higher order contract function for registry.canBeWhitelisted

### DIFF
--- a/spec/computable/registry/challenge.spec.ts
+++ b/spec/computable/registry/challenge.spec.ts
@@ -311,4 +311,22 @@ describe('Registry: Challenge', () => {
     expect(revealAfter).toBe(true)
   })
 
+  it('Registry can be waitlisted after application stage length.', async () => {
+    const listBytes = stringToBytes(web3, 'listing.net')
+
+    const beforeResult = await registry.canBeWhitelisted(listBytes)
+    expect(beforeResult).toBe(false)
+
+    const tx1 = registry.apply(listBytes, ParameterDefaults.MIN_DEPOSIT, '', { from: applicant })
+    expect(tx1).toBeTruthy()
+
+    const result = await registry.canBeWhitelisted(listBytes)
+    expect(result).toBe(false)
+
+    await increaseTime(provider, ParameterDefaults.COMMIT_STAGE_LENGTH + 1)
+
+    const resultAfterCommitStage = await registry.canBeWhitelisted(listBytes)
+    expect(resultAfterCommitStage).toBe(true)
+  })
+
 })

--- a/spec/computable/registry/challenge.spec.ts
+++ b/spec/computable/registry/challenge.spec.ts
@@ -311,7 +311,7 @@ describe('Registry: Challenge', () => {
     expect(revealAfter).toBe(true)
   })
 
-  it('Registry can be waitlisted after application stage length.', async () => {
+  it('Registry can be whitelisted after application stage length.', async () => {
     const listBytes = stringToBytes(web3, 'listing.net')
 
     const beforeResult = await registry.canBeWhitelisted(listBytes)

--- a/src/contracts/registry.ts
+++ b/src/contracts/registry.ts
@@ -233,6 +233,14 @@ export default class extends Deployable {
   }
 
   /**
+   * Determines whether the given listingHash can be whitelisted.
+   */
+  async canBeWhitelisted(listing:string): Promise<boolean> {
+    const deployed = this.requireDeployed()
+    return await deployed.methods.canBeWhitelisted(listing).call()
+  }
+
+  /**
    * Allows the owner of a listingHash to decrease their unstaked deposit.
    *
    * @param listing listing that msg.sender is the owner of


### PR DESCRIPTION
Adds a higher order contract function for `registry.canBeWhitelisted` along with spec.