### PR TITLE
updating contracts and specs for realistic gas costs and signing methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "JASMINE_CONFIG_PATH=./spec/support/jasmine.json jasmine-ts",
     "build": "npm run build:clean && tsc -p ./tsbuild.json && cp -r ./src/@types/** ./dist/@types",
     "build:clean": " rm -rf ./dist",
-    "build:dry": "tsc -noEmit -p ./tsbuild.json",
+    "build:dry": "npm run build:clean && tsc -noEmit -p ./tsbuild.json",
     "prepublish": "npm run build:clean && npm run build",
     "test-init": "jasmine-ts init"
   },

--- a/spec/computable/parameterizer/can-be-set.spec.ts
+++ b/spec/computable/parameterizer/can-be-set.spec.ts
@@ -47,7 +47,7 @@ describe('Parameterizer: canBeSet', () => {
   it('should be truthy if a proposal passed its application stage with no challenge', async () => {
     const emitter = parameterizer.getEventEmitter('_ReparameterizationProposal')
     // the actual call, no need to wait for the TX as we'll use the async listener for an event log
-    parameterizer.proposeReparameterization('voteQuorum', 51)
+    parameterizer.proposeReparameterization(web3, 'voteQuorum', 51)
     // the await here returns the full event log object
     const propID = eventReturnValues('propID', await onData(emitter))
 
@@ -69,7 +69,7 @@ describe('Parameterizer: canBeSet', () => {
   it('should be falsy if proposal did not pass challenge phase', async () => {
     const emitter = parameterizer.getEventEmitter('_ReparameterizationProposal')
     // the actual call, no need to wait for the TX as we'll use the async listener for an event log
-    parameterizer.proposeReparameterization('dispensationPct', 58)
+    parameterizer.proposeReparameterization(web3, 'dispensationPct', 58)
 
     const propID = eventReturnValues('propID', await onData(emitter))
 

--- a/spec/computable/parameterizer/challenge-can-be-resolved.spec.ts
+++ b/spec/computable/parameterizer/challenge-can-be-resolved.spec.ts
@@ -66,10 +66,10 @@ describe('Parameterizer: challengeCanBeResolved', () => {
   it('should be truthy if a challenge is ready to be resolved', async () => {
     const emitter = parameterizer.getEventEmitter('_ReparameterizationProposal')
     // the actual call, no need to wait for the TX as we'll use the async listener for an event log
-    parameterizer.proposeReparameterization('voteQuorum', 51)
+    parameterizer.proposeReparameterization(web3, 'voteQuorum', 51)
 
     const propID = eventReturnValues('propID', await onData(emitter)),
-      tx1 = await parameterizer.challengeReparameterization(propID, { from: accounts[1] })
+      tx1 = await parameterizer.challengeReparameterization(web3, propID, { from: accounts[1] })
 
     expect(tx1).toBeTruthy()
 
@@ -82,10 +82,10 @@ describe('Parameterizer: challengeCanBeResolved', () => {
 
   it('should be falsy if challenge not ready', async () => {
     const emitter = parameterizer.getEventEmitter('_ReparameterizationProposal')
-    parameterizer.proposeReparameterization('voteQuorum', 51)
+    parameterizer.proposeReparameterization(web3, 'voteQuorum', 51)
 
     const propID = eventReturnValues('propID', await onData(emitter)),
-      tx1 = await parameterizer.challengeReparameterization(propID, { from: accounts[1] })
+      tx1 = await parameterizer.challengeReparameterization(web3, propID, { from: accounts[1] })
 
     expect(tx1).toBeTruthy()
 

--- a/spec/computable/parameterizer/challenge-reparam.spec.ts
+++ b/spec/computable/parameterizer/challenge-reparam.spec.ts
@@ -126,7 +126,7 @@ describe('Parameterizer: challengeReparameterization', () => {
 
     await increaseTime(provider, ParameterDefaults.P_COMMIT_STAGE_LENGTH + 1)
 
-    const tx3 = await voting.revealVote(id, 1, 420, { from: accounts[2] })
+    const tx3 = await voting.revealVote(web3, id, 1, 420, { from: accounts[2] })
     expect(tx3).toBeTruthy()
 
     await increaseTime(provider, ParameterDefaults.P_REVEAL_STAGE_LENGTH + 1)

--- a/spec/computable/parameterizer/challenge-reparam.spec.ts
+++ b/spec/computable/parameterizer/challenge-reparam.spec.ts
@@ -80,16 +80,16 @@ describe('Parameterizer: challengeReparameterization', () => {
       startingBalOne = await erc20.balanceOf(accounts[1]),
       emitter = parameterizer.getEventEmitter('_ReparameterizationProposal')
 
-    parameterizer.proposeReparameterization('voteQuorum', 51)
+    parameterizer.proposeReparameterization(web3, 'voteQuorum', 51)
 
     const propID = eventReturnValues('propID', await onData(emitter)),
-      tx1 = await parameterizer.challengeReparameterization(propID, { from: accounts[1] })
+      tx1 = await parameterizer.challengeReparameterization(web3, propID, { from: accounts[1] })
 
     expect(tx1).toBeTruthy()
 
     await increaseTime(provider, ParameterDefaults.P_COMMIT_STAGE_LENGTH + ParameterDefaults.P_REVEAL_STAGE_LENGTH + 1)
 
-    const tx2 = await parameterizer.processProposal(propID)
+    const tx2 = await parameterizer.processProposal(web3, propID)
     expect(tx2).toBeTruthy()
 
     const voteQ = await parameterizer.get('voteQuorum')
@@ -112,11 +112,11 @@ describe('Parameterizer: challengeReparameterization', () => {
       reParamEmitter = parameterizer.getEventEmitter('_ReparameterizationProposal'),
       challEmitter = parameterizer.getEventEmitter('_NewChallenge')
 
-    parameterizer.proposeReparameterization('voteQuorum', 51)
+    parameterizer.proposeReparameterization(web3, 'voteQuorum', 51)
 
     const propID = eventReturnValues('propID', await onData(reParamEmitter))
 
-    parameterizer.challengeReparameterization(propID, { from: accounts[1] })
+    parameterizer.challengeReparameterization(web3, propID, { from: accounts[1] })
 
     const id = eventReturnValues('id', await onData(challEmitter)),
       // accounts[2] as voter here TODO setup some spec-level constants
@@ -130,7 +130,7 @@ describe('Parameterizer: challengeReparameterization', () => {
     expect(tx3).toBeTruthy()
 
     await increaseTime(provider, ParameterDefaults.P_REVEAL_STAGE_LENGTH + 1)
-    await parameterizer.processProposal(propID)
+    await parameterizer.processProposal(web3, propID)
 
     const quorum = await parameterizer.get('voteQuorum')
     expect(quorum).toBe('51')

--- a/spec/computable/parameterizer/proposals.spec.ts
+++ b/spec/computable/parameterizer/proposals.spec.ts
@@ -75,7 +75,7 @@ describe('Parameterizer: Reparamaterize', () => {
 
       // the emitter must be fetched before the proposition is made or it wont fire
       const emitter = parameterizer.getEventEmitter('_ReparameterizationProposal')
-      parameterizer.proposeReparameterization('voteQuorum', 51)
+      parameterizer.proposeReparameterization(web3, 'voteQuorum', 51)
 
       // its ok to await the event after the proposition, as long as the emitter was fetched first
       const propID = eventReturnValues('propID', await onData(emitter)),

--- a/spec/computable/parameterizer/propose-reparam.spec.ts
+++ b/spec/computable/parameterizer/propose-reparam.spec.ts
@@ -46,13 +46,13 @@ describe('Parameterizer: Process a proposal', () => {
     expect(applicantStartingBalance).toBe('5000000')
 
     const emitter = parameterizer.getEventEmitter('_ReparameterizationProposal')
-    parameterizer.proposeReparameterization('voteQuorum', 51)
+    parameterizer.proposeReparameterization(web3, 'voteQuorum', 51)
 
     const propID = eventReturnValues('propID', await onData(emitter))
 
     await increaseTime(provider, ParameterDefaults.P_APPLY_STAGE_LENGTH + 1)
 
-    const tx3 = await parameterizer.processProposal(propID)
+    const tx3 = await parameterizer.processProposal(web3, propID)
     expect(tx3).toBeTruthy()
     // we should see the changes now
     const vq = await parameterizer.get('voteQuorum')

--- a/spec/computable/registry/app-was-made.spec.ts
+++ b/spec/computable/registry/app-was-made.spec.ts
@@ -26,10 +26,10 @@ let web3:Web3,
 
 const users = [{
     secretKey: '0x71cc6e70f524061c36f6b9091889785f6e777d489267334bbef1c129cb7d0d69',
-    balance: 1000000000000,
+    balance: 1000000000000000000, // 1 ETH in wei
   }, {
     secretKey: '0x81cc6e70f524061c36f6b9091889785f6e777d489267334bbef1c129cb7d0d70',
-    balance: 1000000000000,
+    balance: 1000000000000000000,
   }]
 
 describe('Registry', () => {

--- a/spec/computable/registry/apply.spec.ts
+++ b/spec/computable/registry/apply.spec.ts
@@ -20,10 +20,10 @@ import {
 // define users and private keys so we can test signed transactions as well
 const users = [{
     secretKey: '0x71cc6e70f524061c36f6b9091889785f6e777d489267334bbef1c129cb7d0d69',
-    balance: 1000000000000,
+    balance: 1000000000000000000, // 1 ETH in wei
   }, {
     secretKey: '0x81cc6e70f524061c36f6b9091889785f6e777d489267334bbef1c129cb7d0d70',
-    balance: 1000000000000,
+    balance: 1000000000000000000,
   }]
 
 const provider:any = ganache.provider({ accounts: users }),
@@ -77,8 +77,11 @@ describe('Registry: Apply', () => {
 
   it('allows a new application', async () => {
     const listBytes = stringToBytes(web3, 'listing.com'),
-      // use a signed transacion, should behave the same as a non-signed
-      tx1 = await registry.apply(web3, listBytes, ParameterDefaults.MIN_DEPOSIT, undefined, {gas: 500000, sign: users[0].secretKey.substring(2)}),
+      // use a signed transacion, get estimates for gas && price
+      price = web3.eth.getGasPrice(),
+      gas = await registry.apply(web3, listBytes, ParameterDefaults.MIN_DEPOSIT, '', { estimateGas: true }), // NOTE you only need send the args the bytecode method expects
+      // we have to make the secret keys actual secret keys and not the faux-hexed ones above... real use cases won't need to substr...
+      tx1 = await registry.apply(web3, listBytes, ParameterDefaults.MIN_DEPOSIT, undefined, {gas: gas, gasPrice: price, sign: users[0].secretKey.substr(2)}),
       // grab the block number so we can grab the events that happened
       block = tx1.blockNumber
 
@@ -165,13 +168,13 @@ describe('Registry: Apply', () => {
       const maxUint = new BigNumber(2).pow(256).minus(bigOne),
         applyStageLen = maxUint.minus(new BigNumber(block.timestamp)).plus(bigOne),
         propID = eventsReturnValues('_ReparameterizationProposal',
-          await parameterizer.proposeReparameterization('applyStageLen',
+          await parameterizer.proposeReparameterization(web3, 'applyStageLen',
             applyStageLen.toString(10), { from: accounts[1] }), 'propID')
 
       expect(propID).toBeTruthy()
 
       await increaseTime(provider, ParameterDefaults.P_APPLY_STAGE_LENGTH + 1)
-      await parameterizer.processProposal(propID)
+      await parameterizer.processProposal(web3, propID)
 
       // assure prop was processed
       const actualLen = await parameterizer.get('applyStageLen')

--- a/spec/computable/registry/apply.spec.ts
+++ b/spec/computable/registry/apply.spec.ts
@@ -78,7 +78,7 @@ describe('Registry: Apply', () => {
   it('allows a new application', async () => {
     const listBytes = stringToBytes(web3, 'listing.com'),
       // use a signed transacion, get estimates for gas && price
-      price = web3.eth.getGasPrice(),
+      price = await web3.eth.getGasPrice(),
       gas = await registry.apply(web3, listBytes, ParameterDefaults.MIN_DEPOSIT, '', { estimateGas: true }), // NOTE you only need send the args the bytecode method expects
       // we have to make the secret keys actual secret keys and not the faux-hexed ones above... real use cases won't need to substr...
       tx1 = await registry.apply(web3, listBytes, ParameterDefaults.MIN_DEPOSIT, undefined, {gas: gas, gasPrice: price, sign: users[0].secretKey.substr(2)}),

--- a/spec/computable/registry/challenge.spec.ts
+++ b/spec/computable/registry/challenge.spec.ts
@@ -204,11 +204,11 @@ describe('Registry: Challenge', () => {
 
     // propose a new min_deposit... old one is 10
     const propID = eventReturnValues('_ReparameterizationProposal',
-      await parameterizer.proposeReparameterization('minDeposit', 20, { from: proposer }), 'propID')
+      await parameterizer.proposeReparameterization(web3, 'minDeposit', 20, { from: proposer }), 'propID')
     expect(propID).toBeTruthy()
 
     await increaseTime(provider, ParameterDefaults.P_APPLY_STAGE_LENGTH + 1)
-    await parameterizer.processProposal(propID)
+    await parameterizer.processProposal(web3, propID)
 
     const challengerStartBal = await erc20.balanceOf(challenger)
     await registry.challenge(web3, listBytes, '', { from: challenger })

--- a/spec/computable/registry/challenge.spec.ts
+++ b/spec/computable/registry/challenge.spec.ts
@@ -152,7 +152,7 @@ describe('Registry: Challenge', () => {
     // 1 serving as a truthy vote for the challenged, i.e a falsy vote and it would not be listed
     await voting.commitVote(web3, id, voter, 1, 10, 420)
     await increaseTime(provider, ParameterDefaults.COMMIT_STAGE_LENGTH + 1)
-    await voting.revealVote(id, 1, 420, { from: voter })
+    await voting.revealVote(web3, id, 1, 420, { from: voter })
     await increaseTime(provider, ParameterDefaults.REVEAL_STAGE_LENGTH + 1)
     await registry.updateStatus(web3, listBytes)
 
@@ -180,7 +180,7 @@ describe('Registry: Challenge', () => {
     // vote to support
     await voting.commitVote(web3, id, voter, 1, 10, 420)
     await increaseTime(provider, ParameterDefaults.COMMIT_STAGE_LENGTH + 1)
-    await voting.revealVote(id, 1, 420, { from: voter })
+    await voting.revealVote(web3, id, 1, 420, { from: voter })
     await increaseTime(provider, ParameterDefaults.REVEAL_STAGE_LENGTH + 1)
     await registry.updateStatus(web3, listBytes)
     // with the support vote should have succeeded

--- a/spec/computable/registry/claim-reward.spec.ts
+++ b/spec/computable/registry/claim-reward.spec.ts
@@ -121,7 +121,7 @@ describe('Registry: Claim Reward', () => {
     await increaseTime(provider, ParameterDefaults.COMMIT_STAGE_LENGTH + 1)
 
     // Reveal vote
-    await voting.revealVote(id, 0, 420, { from: voter })
+    await voting.revealVote(web3, id, 0, 420, { from: voter })
     await increaseTime(provider, ParameterDefaults.REVEAL_STAGE_LENGTH + 1)
     await registry.updateStatus(web3, listBytes)
 
@@ -135,7 +135,7 @@ describe('Registry: Claim Reward', () => {
     await registry.claimReward(web3, id, 420, {from: voter})
 
     // Voter withdraws voting rights
-    await voting.withdrawVotingRights(10, {from: voter})
+    await voting.withdrawVotingRights(web3, 10, {from: voter})
 
     // Get final voter balance
     const voterFinalBalance = maybeParseInt(await erc20.balanceOf(voter))

--- a/spec/computable/token/erc-20.spec.ts
+++ b/spec/computable/token/erc-20.spec.ts
@@ -75,6 +75,11 @@ describe('Erc20 Token', () => {
   })
 
   describe('Approvals', () => {
+    it('can estimate gas for an approval', async () => {
+      const result = await erc20.approve(web3, accounts[1], 1000, { estimateGas: true })
+      expect(result).toBeTruthy()
+    })
+
     it('sender approves account[1] for 1000', async () => {
       await erc20.approve(web3, accounts[1], 1000)
       const allowance = await erc20.allowance(accounts[0], accounts[1])

--- a/src/constants/general.ts
+++ b/src/constants/general.ts
@@ -1,10 +1,6 @@
 export const NAME:string = 'Computable Labs: Data Marketplace'
 export const ONE_THOUSAND:number = 1000
 export const ONE_MILLION:number = 1000000
-export const GAS:number = 4500000
-export const GAS_PRICE:number = 100
-
-// atm same as GAS
-export const TEST_NET_GAS:number = 4500000
-// TODO change this? seems high...
-export const TEST_NET_GAS_PRICE:number = 25000000000
+export const DEPLOYMENT_GAS = 4700000 // ye old gas block limit of 4.7M should be enuff
+export const GAS:number = 1000000 // nothing outside of deployment should cost this much
+export const GAS_PRICE:number = 2000000000 // 2B wei, a low but typical gas price

--- a/src/contracts/erc-20.ts
+++ b/src/contracts/erc-20.ts
@@ -17,7 +17,7 @@ export default class extends Deployable {
   /**
    * An amount of funds an owner has given a spender permission to use
    */
-  async allowance(owner:string, spender:string): Promise<Nos> {
+  allowance(owner:string, spender:string): Promise<Nos> {
     const deployed = this.requireDeployed()
 
     return deployed.methods.allowance(owner, spender).call()
@@ -25,24 +25,27 @@ export default class extends Deployable {
   /**
    * Grant permission to a spender located at the given address to use up to the given amount of funds
    */
-  async approve(web3:Web3, address:string, amount:Nos, opts?:ContractOptions): Promise<TransactionReceipt> {
+  approve(web3:Web3, address:string, amount:Nos, opts?:ContractOptions): Promise<TransactionReceipt> {
     const deployed = this.requireDeployed(),
-      account = this.requireAccount(opts)
+      account = this.requireAccount(opts),
+      options = this.assignContractOptions({ from: account }, opts)
 
+    // the presence of opts.estimateGas takes precedence
+    if (options.estimateGas) return deployed.methods.approve(address, amount).estimateGas()
     // the presence of opts.sign (or lack thereof) determines how we call for this (value should be a private key)
-    if (opts && opts.sign) {
+    else if (options.sign) {
       // the called method is always responsible for getting the abi encoded method here
       const encoded = deployed.methods.approve(address, amount).encodeABI()
       // use the helper to actually send a signed transaction (web3, to, from, encodedABI, opts)
-      return await sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
-    } else return await deployed.methods.approve(address, amount).send(this.assignContractOptions({ from: account }, opts))
+      return sendSignedTransaction(web3, deployed.options.address, account, encoded, options)
+    } else return deployed.methods.approve(address, amount).send(options)
   }
 
   /**
    * Set our deployed refernce from an already deployed contract
    * @see abstracts/deployable#at
    */
-  async at(web3:Web3, params:AtParams, opts?:ContractOptions): Promise<boolean> {
+  at(web3:Web3, params:AtParams, opts?:ContractOptions): Promise<boolean> {
     const ap:AtParams = {
       address: params.address,
       abi: tokenJson.abi,
@@ -55,10 +58,10 @@ export default class extends Deployable {
   /**
    * Return the current balance of the given address
    */
-  async balanceOf(address:string): Promise<Nos> {
+  balanceOf(address:string): Promise<Nos> {
     const deployed = this.requireDeployed()
 
-    return await deployed.methods.balanceOf(address).call()
+    return deployed.methods.balanceOf(address).call()
   }
 
   /**
@@ -66,7 +69,7 @@ export default class extends Deployable {
    * contract options to the super class' deployContract method.
    * @see abstracts/deployable#deployContract
    */
-  async deploy(web3:Web3, params:Erc20DeployParams = {}, opts?:ContractOptions): Promise<string> {
+  deploy(web3:Web3, params:Erc20DeployParams = {}, opts?:ContractOptions): Promise<string> {
     const dp:DeployParams = {
       abi: tokenJson.abi,
       bytecode: tokenJson.bytecode,
@@ -83,26 +86,30 @@ export default class extends Deployable {
   /**
    * Move the given number of funds from the msg.sender to a given address
    */
-  async transfer(web3:Web3, address:string, amount:Nos, opts?:ContractOptions): Promise<TransactionReceipt> {
+  transfer(web3:Web3, address:string, amount:Nos, opts?:ContractOptions): Promise<TransactionReceipt> {
     const deployed = this.requireDeployed(),
-      account = this.requireAccount(opts)
+      account = this.requireAccount(opts),
+      options = this.assignContractOptions({ from: account }, opts)
 
-    if (opts && opts.sign) {
+    if (options.estimateGas) return deployed.methods.transfer(address, amount).estimateGas()
+    else if (options.sign) {
       const encoded = deployed.methods.transfer(address, amount).encodeABI()
-      return await sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
-    } else return await deployed.methods.transfer(address, amount).send(this.assignContractOptions({ from: account }, opts))
+      return sendSignedTransaction(web3, deployed.options.address, account, encoded, options)
+    } else return deployed.methods.transfer(address, amount).send(options)
   }
 
   /**
    * Move the given number of funds from one given address to another given address
    */
-  async transferFrom(web3:Web3, from:string, to:string, amount:Nos, opts?:ContractOptions): Promise<TransactionReceipt> {
+  transferFrom(web3:Web3, from:string, to:string, amount:Nos, opts?:ContractOptions): Promise<TransactionReceipt> {
     const deployed = this.requireDeployed(),
-      account = this.requireAccount(opts)
+      account = this.requireAccount(opts),
+      options = this.assignContractOptions({ from: account }, opts)
 
-    if (opts && opts.sign) {
+    if (options.estimateGas) return deployed.methods.transferFrom(from, to, amount).estimateGas()
+    if (options.sign) {
       const encoded = deployed.methods.transferFrom(from, to, amount).encodeABI()
-      return await sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
-    } else return await deployed.methods.transferFrom(from, to, amount).send(this.assignContractOptions({ from: account }, opts))
+      return sendSignedTransaction(web3, deployed.options.address, account, encoded, options)
+    } else return deployed.methods.transferFrom(from, to, amount).send(options)
   }
 }

--- a/src/contracts/parameterizer.ts
+++ b/src/contracts/parameterizer.ts
@@ -170,7 +170,7 @@ export default class extends Deployable {
 
     if (options.estimateGas) return deployed.methods.proposeReparameterization(attribute, val).estimateGas()
     else if (options.sign) {
-      const encoded = deployed.methods.processProposal(attribute, val).encodeABI()
+      const encoded = deployed.methods.proposeReparameterization(attribute, val).encodeABI()
       return sendSignedTransaction(web3, deployed.options.address, account, encoded, options)
     }
     else return deployed.methods.proposeReparameterization(attribute, val).send(options)

--- a/src/contracts/parameterizer.ts
+++ b/src/contracts/parameterizer.ts
@@ -4,6 +4,7 @@ import { ParameterDefaults, GAS, GAS_PRICE, Errors } from '../constants'
 import Deployable from '../abstracts/deployable'
 import { Nos } from '../@types'
 import parameterizerJson from '../../computable/build/contracts/Parameterizer.json'
+import { sendSignedTransaction } from '../helpers'
 // TODO PR web3 to export these properly
 import {
   Keyed,
@@ -44,7 +45,7 @@ export default class extends Deployable {
    * Set our deployed refernce from an already deployed contract
    * @see abstracts/deployable#at
    */
-  async at(web3:Web3, params:AtParams, opts?:ContractOptions): Promise<boolean> {
+  at(web3:Web3, params:AtParams, opts?:ContractOptions): Promise<boolean> {
     const ap:AtParams = {
       address: params.address,
       abi: parameterizerJson.abi,
@@ -56,29 +57,34 @@ export default class extends Deployable {
   /**
    * Determines if a proposal passed its application stage without a challenge
    */
-  async canBeSet(propID:string): Promise<boolean> {
+  canBeSet(hash:string): Promise<boolean> {
     const deployed = this.requireDeployed()
 
-    return await deployed.methods.canBeSet(propID).call()
+    return deployed.methods.canBeSet(hash).call()
   }
 
   /**
-   * Determines whether the provided proposal ID has a challenge which can be resolved
+   * Determines whether the identified proposal has a challenge which can be resolved
    */
-  async challengeCanBeResolved(propID:string): Promise<boolean> {
+  challengeCanBeResolved(hash:string): Promise<boolean> {
     const deployed = this.requireDeployed()
 
-    return await deployed.methods.challengeCanBeResolved(propID).call()
+    return deployed.methods.challengeCanBeResolved(hash).call()
   }
 
   /**
    * Challenge a given proposal ID, and stake tokens to do so
    */
-  async challengeReparameterization(propID:string, opts?:ContractOptions): Promise<TransactionReceipt> {
+  challengeReparameterization(web3:Web3, hash:string, opts?:ContractOptions): Promise<TransactionReceipt> {
     const deployed = this.requireDeployed(),
-      account = this.requireAccount(opts)
+      account = this.requireAccount(opts),
+      options = this.assignContractOptions({ from: account }, opts)
 
-    return await deployed.methods.challengeReparameterization(propID).send({ from: account })
+    if (options.estimateGas) return deployed.methods.challengeReparameterization(hash).estimateGas()
+    else if (options.sign) {
+      const encoded = deployed.methods.challengeReparameterization(hash).encodeABI()
+      return sendSignedTransaction(web3, deployed.options.address, account, encoded, options)
+    } else return deployed.methods.challengeReparameterization(hash).send(options)
   }
 
   /**
@@ -86,7 +92,7 @@ export default class extends Deployable {
    * contract options to the super class' _deploy method.
    * @see abstracts/deployable#deployContract
    */
-  async deploy(web3:Web3, params:ParameterizerDeployParams, opts?:ContractOptions): Promise<string> {
+  deploy(web3:Web3, params:ParameterizerDeployParams, opts?:ContractOptions): Promise<string> {
     const dp:DeployParams = {
       abi: parameterizerJson.abi,
       bytecode: parameterizerJson.bytecode,
@@ -114,48 +120,59 @@ export default class extends Deployable {
   /**
    * Fetch a given attribute as it is set on the deployed contract
    */
-  async get(attribute:string): Promise<Nos> {
+  get(attribute:string): Promise<Nos> {
     const deployed = this.requireDeployed()
 
-    return await deployed.methods.get(attribute).call()
+    return deployed.methods.get(attribute).call()
   }
 
   /**
    * For the given proposal ID, set it, resolve its challenge, or delete it depending on whether it can be set,
    * has a challenge which can be resolved, or if its "process by" date has passed
    */
-  async processProposal(propID:string, opts?:ContractOptions): Promise<TransactionReceipt> {
+  processProposal(web3:Web3, hash:string, opts?:ContractOptions): Promise<TransactionReceipt> {
     const deployed = this.requireDeployed(),
-      account = this.requireAccount(opts)
+      account = this.requireAccount(opts),
+      options = this.assignContractOptions({ from: account }, opts)
 
-    return await deployed.methods.processProposal(propID).send({ from: account })
+    if (options.estimateGas) return deployed.methods.processProposal(hash).estimateGas()
+    else if (options.sign) {
+      const encoded = deployed.methods.processProposal(hash).encodeABI()
+      return sendSignedTransaction(web3, deployed.options.address, account, encoded, options)
+    } else return deployed.methods.processProposal(hash).send(options)
   }
 
   /**
    * Determines whether a proposal exists for the provided proposal ID
    */
-  async propExists(propID:string): Promise<boolean> {
+  propExists(hash:string): Promise<boolean> {
     const deployed = this.requireDeployed()
 
-    return await deployed.methods.propExists(propID).call()
+    return deployed.methods.propExists(hash).call()
   }
 
   /**
    * Proposals map pollIDs to intended data change if poll passes
    */
-  async proposals(propID:string): Promise<ParameterizerProposal> {
+  proposals(hash:string): Promise<ParameterizerProposal> {
     const deployed = this.requireDeployed()
 
-    return await deployed.methods.proposals(propID).call()
+    return deployed.methods.proposals(hash).call()
   }
 
   /**
    * Propose a change of the given attribute to the given value
    */
-  async proposeReparameterization(attribute:string, val:Nos, opts?:ContractOptions): Promise<TransactionReceipt> {
+  proposeReparameterization(web3:Web3, attribute:string, val:Nos, opts?:ContractOptions): Promise<TransactionReceipt> {
     const deployed = this.requireDeployed(),
-      account = this.requireAccount(opts)
+      account = this.requireAccount(opts),
+      options = this.assignContractOptions({ from: account }, opts)
 
-    return await deployed.methods.proposeReparameterization(attribute, val).send({ from: account })
+    if (options.estimateGas) return deployed.methods.proposeReparameterization(attribute, val).estimateGas()
+    else if (options.sign) {
+      const encoded = deployed.methods.processProposal(attribute, val).encodeABI()
+      return sendSignedTransaction(web3, deployed.options.address, account, encoded, options)
+    }
+    else return deployed.methods.proposeReparameterization(attribute, val).send(options)
   }
 }

--- a/src/contracts/registry.ts
+++ b/src/contracts/registry.ts
@@ -55,23 +55,24 @@ export default class extends Deployable {
    * @param tokens The number of ERC20 tokens a user is willing to potentially stake
    * @param data Extra data relevant to the application. Think IPFS hashes.
    */
-  async apply(web3:Web3, listing:string, tokens:Nos, data:string = '', opts?:ContractOptions): Promise<TransactionReceipt> {
+  apply(web3:Web3, listing:string, tokens:Nos, data:string = '', opts?:ContractOptions): Promise<TransactionReceipt> {
     const deployed = this.requireDeployed(),
       account = this.requireAccount(opts)
 
+    if (opts && opts.estimateGas) return deployed.methods.apply(listing, tokens, data).estimateGas()
     // the presence of opts.sign (or lack thereof) determines how we call for this (value should be a private key)
-    if (opts && opts.sign) {
+    else if (opts && opts.sign) {
       // the called method is always responsible for getting the abi encoded method here
       const encoded = deployed.methods.apply(listing, tokens, data).encodeABI()
       // use the helper to actually send a signed transaction (web3, to, from, encodedABI, opts)
-      return await sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
-    } else return await deployed.methods.apply(listing, tokens, data).send(this.assignContractOptions({ from: account}, opts))
+      return sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
+    } else return deployed.methods.apply(listing, tokens, data).send(this.assignContractOptions({ from: account}, opts))
   }
 
   /**
    * Returns a bool that indicates if `apply` was called for a given listing hash
    */
-  async appWasMade(listing:string): Promise<boolean> {
+  appWasMade(listing:string): Promise<boolean> {
     const deployed = this.requireDeployed()
 
     return deployed.methods.appWasMade(listing).call()
@@ -81,7 +82,7 @@ export default class extends Deployable {
    * Set our deployed refernce from an already deployed contract
    * @see abstracts/deployable#at
    */
-  async at(web3:Web3, params:AtParams, opts?:ContractOptions): Promise<boolean> {
+  at(web3:Web3, params:AtParams, opts?:ContractOptions): Promise<boolean> {
     const ap:AtParams = {
       address: params.address,
       abi: registryJson.abi,
@@ -97,39 +98,42 @@ export default class extends Deployable {
    * @param listing The hash being challenged, whether listed or in application
    * @param data Extra data relevant to the challenge. Think IPFS hashes.
    */
-  async challenge(web3:Web3, listing:string, data:string = '', opts?:ContractOptions): Promise<TransactionReceipt> {
+  challenge(web3:Web3, listing:string, data:string = '', opts?:ContractOptions): Promise<TransactionReceipt> {
     const deployed = this.requireDeployed(),
       account = this.requireAccount(opts)
 
-    if (opts && opts.sign) {
+    if (opts && opts.estimateGas) return deployed.methods.challenge(listing, data).estimateGas()
+    else if (opts && opts.sign) {
       // the called method is always responsible for getting the abi encoded method here
       const encoded = deployed.methods.challenge(listing, data).encodeABI()
       // use the helper to actually send a signed transaction (web3, to, from, encodedABI, opts)
-      return await sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
-    } else return await deployed.methods.challenge(listing, data).send(this.assignContractOptions({ from: account }, opts))
+      return sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
+    } else return deployed.methods.challenge(listing, data).send(this.assignContractOptions({ from: account }, opts))
   }
 
   /**
    * Return a challenge corresponding to the given ID.
    */
-  async challenges(id:Nos): Promise<Challenge> {
+  challenges(id:Nos): Promise<Challenge> {
     const deployed = this.requireDeployed()
 
-    return await deployed.methods.challenges(id).call()
+    return deployed.methods.challenges(id).call()
   }
 
   /**
    * Called by voter to claim their reward for each completed vote. Must be preceded by call to updateStatus
    */
-  async claimReward(web3:Web3, id:Nos, salt:Nos, opts?:ContractOptions): Promise<TransactionReceipt> {
+  claimReward(web3:Web3, id:Nos, salt:Nos, opts?:ContractOptions): Promise<TransactionReceipt> {
     const account = this.requireAccount(opts),
       deployed = this.requireDeployed()
-    if (opts && opts.sign) {
+
+    if (opts && opts.estimateGas) return deployed.methods.claimReward(id, salt).estimateGas()
+    else if (opts && opts.sign) {
       // the called method is always responsible for getting the abi encoded method here
       const encoded = deployed.methods.claimReward(id, salt).encodeABI()
       // use the helper to actually send a signed transaction (web3, to, from, encodedABI, opts)
-      return await sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
-    } else return await deployed.methods.claimReward(id, salt).send(this.assignContractOptions({from: account}, opts))
+      return sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
+    } else return deployed.methods.claimReward(id, salt).send(this.assignContractOptions({from: account}, opts))
   }
 
   /**
@@ -137,7 +141,7 @@ export default class extends Deployable {
    * contract options to the super class' _deploy method.
    * @see abstracts/deployable#deployContract
    */
-  async deploy(web3:Web3, params:RegistryDeployParams, opts?:ContractOptions): Promise<string> {
+  deploy(web3:Web3, params:RegistryDeployParams, opts?:ContractOptions): Promise<string> {
     const dp:DeployParams = {
       abi: registryJson.abi,
       bytecode: registryJson.bytecode,
@@ -157,14 +161,15 @@ export default class extends Deployable {
    * @param listing listing that msg.sender is the owner of
    * @param amount how much to increase by
    */
-  async deposit(web3:Web3, listing:string, amount:Nos, opts?:ContractOptions): Promise<TransactionReceipt> {
+  deposit(web3:Web3, listing:string, amount:Nos, opts?:ContractOptions): Promise<TransactionReceipt> {
     const account = this.requireAccount(opts),
       deployed = this.requireDeployed()
 
-    if (opts && opts.sign) {
+    if (opts && opts.estimateGas) return deployed.methods.deposit(listing, amount).estimateGas()
+    else if (opts && opts.sign) {
       const encoded = deployed.methods.deposit(listing, amount).encodeABI()
-      return await sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
-    } else return await deployed.methods.deposit(listing, amount).send(this.assignContractOptions({ from: account }, opts))
+      return sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
+    } else return deployed.methods.deposit(listing, amount).send(this.assignContractOptions({ from: account }, opts))
   }
 
   /**
@@ -172,98 +177,100 @@ export default class extends Deployable {
    * Returns all tokens to the owner of the listingHash
    * @param listing listing that msg.sender is the owner of
    */
-  async exit(web3:Web3, listing:string, opts?:ContractOptions): Promise<TransactionReceipt> {
+  exit(web3:Web3, listing:string, opts?:ContractOptions): Promise<TransactionReceipt> {
     const deployed = this.requireDeployed(),
       account = this.requireAccount(opts)
 
-    if (opts && opts.sign) {
+    if (opts && opts.estimateGas) return deployed.methods.exit(listing).estimateGas()
+    else if (opts && opts.sign) {
       const encoded = deployed.methods.exit(listing).encodeABI()
-      return await sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
-    } else return await deployed.methods.exit(listing).send(this.assignContractOptions({ from: account }, opts))
+      return sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
+    } else return deployed.methods.exit(listing).send(this.assignContractOptions({ from: account }, opts))
   }
 
   /**
    * Return a bool indicating if this listing has been whitelisted
    */
-  async isWhitelisted(listing:string): Promise<boolean> {
+  isWhitelisted(listing:string): Promise<boolean> {
     const deployed = this.requireDeployed()
 
-    return await deployed.methods.isWhitelisted(listing).call()
+    return deployed.methods.isWhitelisted(listing).call()
   }
 
   /**
    * Return a listing corresponding to the given listing hash.
    */
-  async listings(listing:string): Promise<RegistryListing> {
+  listings(listing:string): Promise<RegistryListing> {
     const deployed = this.requireDeployed()
 
-    return await deployed.methods.listings(listing).call()
+    return deployed.methods.listings(listing).call()
   }
 
   /**
    * Return the name passed to this contract instance at deploy time
    */
-  async name(): Promise<string> {
+  name(): Promise<string> {
     const deployed = this.requireDeployed()
 
-    return await deployed.methods.name().call()
+    return deployed.methods.name().call()
   }
 
   /**
    * Return the address of the parameterizer referenced by this contract instance
    */
-  async parameterizer(): Promise<string> {
+  parameterizer(): Promise<string> {
     const deployed = this.requireDeployed()
 
-    return await deployed.methods.parameterizer().call()
+    return deployed.methods.parameterizer().call()
   }
 
   /**
    * Return the address of the token referenced by this contract instance
    */
-  async token(): Promise<string> {
+  token(): Promise<string> {
     const deployed = this.requireDeployed()
 
-    return await deployed.methods.token().call()
+    return deployed.methods.token().call()
   }
 
   /**
    * Updates a listingHash's status from 'application' to 'listing' or resolves a challenge if one exists.
    * Delegates to `whitelistApplication` or `resolveChallenge`
    */
-  async updateStatus(web3:Web3, listing:string, opts?:ContractOptions): Promise<TransactionReceipt> {
+  updateStatus(web3:Web3, listing:string, opts?:ContractOptions): Promise<TransactionReceipt> {
     const account = this.requireAccount(opts),
       deployed = this.requireDeployed()
 
-    if (opts && opts.sign) {
+    if (opts && opts.estimateGas) return deployed.methods.updateStatus(listing).estimateGas()
+    else if (opts && opts.sign) {
       const encoded = deployed.methods.updateStatus(listing).encodeABI()
-      return await sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
-    } else return await deployed.methods.updateStatus(listing).send(this.assignContractOptions({ from: account }, opts))
+      return sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
+    } else return deployed.methods.updateStatus(listing).send(this.assignContractOptions({ from: account }, opts))
   }
 
   /**
    * Return the address of the plcr-voting referenced by this contract instance
    */
-  async voting(): Promise<string> {
+  voting(): Promise<string> {
     const deployed = this.requireDeployed()
 
-    return await deployed.methods.voting().call()
+    return deployed.methods.voting().call()
   }
 
  /**
   * Return the voter's token reward for the given poll.
   */
-  async voterReward(voter:string, id:Nos, salt:Nos): Promise<Nos> {
+  voterReward(voter:string, id:Nos, salt:Nos): Promise<Nos> {
     const deployed = this.requireDeployed()
-    return await deployed.methods.voterReward(voter, id, salt).call()
+    return deployed.methods.voterReward(voter, id, salt).call()
   }
 
   /**
    * Determines whether the given listingHash can be whitelisted.
    */
-  async canBeWhitelisted(listing:string): Promise<boolean> {
+  canBeWhitelisted(listing:string): Promise<boolean> {
     const deployed = this.requireDeployed()
-    return await deployed.methods.canBeWhitelisted(listing).call()
+    return deployed.methods.canBeWhitelisted(listing).call()
   }
 
   /**
@@ -272,13 +279,14 @@ export default class extends Deployable {
    * @param listing listing that msg.sender is the owner of
    * @param tokens The number of ERC20 tokens to withdraw from unstaked deposity
    */
-  async withdraw(web3:Web3, listing:string, tokens:Nos, opts?:ContractOptions): Promise<TransactionReceipt> {
+  withdraw(web3:Web3, listing:string, tokens:Nos, opts?:ContractOptions): Promise<TransactionReceipt> {
     const deployed = this.requireDeployed(),
       account = this.requireAccount(opts)
 
-    if (opts && opts.sign) {
+    if (opts && opts.estimateGas) return deployed.methods.withdraw(listing, tokens).estimateGas()
+    else if (opts && opts.sign) {
       const encoded = deployed.methods.withdraw(listing, tokens).encodeABI()
-      return await sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
-    } else return await deployed.methods.withdraw(listing, tokens).send(this.assignContractOptions({ from: account }, opts))
+      return sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
+    } else return deployed.methods.withdraw(listing, tokens).send(this.assignContractOptions({ from: account }, opts))
   }
 }

--- a/src/contracts/registry.ts
+++ b/src/contracts/registry.ts
@@ -57,16 +57,17 @@ export default class extends Deployable {
    */
   apply(web3:Web3, listing:string, tokens:Nos, data:string = '', opts?:ContractOptions): Promise<TransactionReceipt> {
     const deployed = this.requireDeployed(),
-      account = this.requireAccount(opts)
+      account = this.requireAccount(opts),
+      options = this.assignContractOptions({ from: account }, opts)
 
-    if (opts && opts.estimateGas) return deployed.methods.apply(listing, tokens, data).estimateGas()
+    if (options.estimateGas) return deployed.methods.apply(listing, tokens, data).estimateGas()
     // the presence of opts.sign (or lack thereof) determines how we call for this (value should be a private key)
-    else if (opts && opts.sign) {
+    else if (options.sign) {
       // the called method is always responsible for getting the abi encoded method here
       const encoded = deployed.methods.apply(listing, tokens, data).encodeABI()
       // use the helper to actually send a signed transaction (web3, to, from, encodedABI, opts)
-      return sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
-    } else return deployed.methods.apply(listing, tokens, data).send(this.assignContractOptions({ from: account}, opts))
+      return sendSignedTransaction(web3, deployed.options.address, account, encoded, options)
+    } else return deployed.methods.apply(listing, tokens, data).send(options)
   }
 
   /**
@@ -100,15 +101,16 @@ export default class extends Deployable {
    */
   challenge(web3:Web3, listing:string, data:string = '', opts?:ContractOptions): Promise<TransactionReceipt> {
     const deployed = this.requireDeployed(),
-      account = this.requireAccount(opts)
+      account = this.requireAccount(opts),
+      options = this.assignContractOptions({ from: account }, opts)
 
-    if (opts && opts.estimateGas) return deployed.methods.challenge(listing, data).estimateGas()
-    else if (opts && opts.sign) {
+    if (options.estimateGas) return deployed.methods.challenge(listing, data).estimateGas()
+    else if (options.sign) {
       // the called method is always responsible for getting the abi encoded method here
       const encoded = deployed.methods.challenge(listing, data).encodeABI()
       // use the helper to actually send a signed transaction (web3, to, from, encodedABI, opts)
-      return sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
-    } else return deployed.methods.challenge(listing, data).send(this.assignContractOptions({ from: account }, opts))
+      return sendSignedTransaction(web3, deployed.options.address, account, encoded, options)
+    } else return deployed.methods.challenge(listing, data).send(options)
   }
 
   /**
@@ -125,15 +127,16 @@ export default class extends Deployable {
    */
   claimReward(web3:Web3, id:Nos, salt:Nos, opts?:ContractOptions): Promise<TransactionReceipt> {
     const account = this.requireAccount(opts),
-      deployed = this.requireDeployed()
+      deployed = this.requireDeployed(),
+      options = this.assignContractOptions({ from: account }, opts)
 
-    if (opts && opts.estimateGas) return deployed.methods.claimReward(id, salt).estimateGas()
-    else if (opts && opts.sign) {
+    if (options.estimateGas) return deployed.methods.claimReward(id, salt).estimateGas()
+    else if (options.sign) {
       // the called method is always responsible for getting the abi encoded method here
       const encoded = deployed.methods.claimReward(id, salt).encodeABI()
       // use the helper to actually send a signed transaction (web3, to, from, encodedABI, opts)
-      return sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
-    } else return deployed.methods.claimReward(id, salt).send(this.assignContractOptions({from: account}, opts))
+      return sendSignedTransaction(web3, deployed.options.address, account, encoded, options)
+    } else return deployed.methods.claimReward(id, salt).send(options)
   }
 
   /**
@@ -163,13 +166,14 @@ export default class extends Deployable {
    */
   deposit(web3:Web3, listing:string, amount:Nos, opts?:ContractOptions): Promise<TransactionReceipt> {
     const account = this.requireAccount(opts),
-      deployed = this.requireDeployed()
+      deployed = this.requireDeployed(),
+      options = this.assignContractOptions({ from: account }, opts)
 
-    if (opts && opts.estimateGas) return deployed.methods.deposit(listing, amount).estimateGas()
+    if (options.estimateGas) return deployed.methods.deposit(listing, amount).estimateGas()
     else if (opts && opts.sign) {
       const encoded = deployed.methods.deposit(listing, amount).encodeABI()
-      return sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
-    } else return deployed.methods.deposit(listing, amount).send(this.assignContractOptions({ from: account }, opts))
+      return sendSignedTransaction(web3, deployed.options.address, account, encoded, options)
+    } else return deployed.methods.deposit(listing, amount).send(options)
   }
 
   /**
@@ -179,13 +183,14 @@ export default class extends Deployable {
    */
   exit(web3:Web3, listing:string, opts?:ContractOptions): Promise<TransactionReceipt> {
     const deployed = this.requireDeployed(),
-      account = this.requireAccount(opts)
+      account = this.requireAccount(opts),
+      options = this.assignContractOptions({ from: account }, opts)
 
-    if (opts && opts.estimateGas) return deployed.methods.exit(listing).estimateGas()
-    else if (opts && opts.sign) {
+    if (options.estimateGas) return deployed.methods.exit(listing).estimateGas()
+    else if (options.sign) {
       const encoded = deployed.methods.exit(listing).encodeABI()
-      return sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
-    } else return deployed.methods.exit(listing).send(this.assignContractOptions({ from: account }, opts))
+      return sendSignedTransaction(web3, deployed.options.address, account, encoded, options)
+    } else return deployed.methods.exit(listing).send(options)
   }
 
   /**
@@ -239,13 +244,14 @@ export default class extends Deployable {
    */
   updateStatus(web3:Web3, listing:string, opts?:ContractOptions): Promise<TransactionReceipt> {
     const account = this.requireAccount(opts),
-      deployed = this.requireDeployed()
+      deployed = this.requireDeployed(),
+      options = this.assignContractOptions({ from: account }, opts)
 
-    if (opts && opts.estimateGas) return deployed.methods.updateStatus(listing).estimateGas()
-    else if (opts && opts.sign) {
+    if (options.estimateGas) return deployed.methods.updateStatus(listing).estimateGas()
+    else if (options.sign) {
       const encoded = deployed.methods.updateStatus(listing).encodeABI()
-      return sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
-    } else return deployed.methods.updateStatus(listing).send(this.assignContractOptions({ from: account }, opts))
+      return sendSignedTransaction(web3, deployed.options.address, account, encoded, options)
+    } else return deployed.methods.updateStatus(listing).send(options)
   }
 
   /**
@@ -281,12 +287,13 @@ export default class extends Deployable {
    */
   withdraw(web3:Web3, listing:string, tokens:Nos, opts?:ContractOptions): Promise<TransactionReceipt> {
     const deployed = this.requireDeployed(),
-      account = this.requireAccount(opts)
+      account = this.requireAccount(opts),
+      options = this.assignContractOptions({ from: account }, opts)
 
-    if (opts && opts.estimateGas) return deployed.methods.withdraw(listing, tokens).estimateGas()
-    else if (opts && opts.sign) {
+    if (options.estimateGas) return deployed.methods.withdraw(listing, tokens).estimateGas()
+    else if (options.sign) {
       const encoded = deployed.methods.withdraw(listing, tokens).encodeABI()
-      return sendSignedTransaction(web3, deployed.options.address, account, encoded, opts)
-    } else return deployed.methods.withdraw(listing, tokens).send(this.assignContractOptions({ from: account }, opts))
+      return sendSignedTransaction(web3, deployed.options.address, account, encoded, options)
+    } else return deployed.methods.withdraw(listing, tokens).send(options)
   }
 }

--- a/src/deploy/deploy.ts
+++ b/src/deploy/deploy.ts
@@ -3,8 +3,9 @@ import Web3 from 'web3'
 import { Contract } from 'web3/types'
 import HDWalletProvider from 'truffle-hdwallet-provider'
 import {
-  TEST_NET_GAS,
-  TEST_NET_GAS_PRICE,
+  GAS,
+  DEPLOYMENT_GAS,
+  GAS_PRICE,
 } from '../constants'
 import Erc20 from '../contracts/erc-20'
 import Voting from '../contracts/plcr-voting'
@@ -47,7 +48,7 @@ web3 = new Web3(provider)
 const deploy = async () => {
   token = new Erc20(account)
   // supply as 2 ETH converted to wei
-  tokenAddress = await token.deploy(web3, { address: account, supply: 2000000000000000000 }, { gas: TEST_NET_GAS, gasPrice: TEST_NET_GAS_PRICE })
+  tokenAddress = await token.deploy(web3, { address: account, supply: 2000000000000000000 }, { gas: DEPLOYMENT_GAS, gasPrice: GAS_PRICE })
   console.log(`TOKEN ADDRESS: ${tokenAddress}`)
 
   dll = await deployDll(web3, account)
@@ -57,16 +58,16 @@ const deploy = async () => {
   attributeStoreAddress = store.options.address
 
   voting = new Voting(account)
-  votingAddress = await voting.deploy(web3, { tokenAddress, dllAddress, attributeStoreAddress }, { gas: TEST_NET_GAS, gasPrice: TEST_NET_GAS_PRICE })
+  votingAddress = await voting.deploy(web3, { tokenAddress, dllAddress, attributeStoreAddress }, { gas: DEPLOYMENT_GAS, gasPrice: GAS_PRICE })
   console.log(`VOTING ADDRESS: ${votingAddress}`)
 
   parameterizer = new Parameterizer(account)
   // allow the p11r to fall back on defaults
-  parameterizerAddress = await parameterizer.deploy(web3, { tokenAddress, votingAddress }, { gas: TEST_NET_GAS, gasPrice: TEST_NET_GAS_PRICE })
+  parameterizerAddress = await parameterizer.deploy(web3, { tokenAddress, votingAddress }, { gas: DEPLOYMENT_GAS, gasPrice: GAS_PRICE })
   console.log(`PARAMETERIZER ADDRESS: ${parameterizerAddress}`)
 
   registry = new Registry(account)
-  registryAddress = await registry.deploy(web3, { tokenAddress, votingAddress, parameterizerAddress, name: 'Computable TCR v0.1.0' }, { gas: TEST_NET_GAS, gasPrice: TEST_NET_GAS_PRICE })
+  registryAddress = await registry.deploy(web3, { tokenAddress, votingAddress, parameterizerAddress, name: 'Computable TCR v0.1.0' }, { gas: DEPLOYMENT_GAS, gasPrice: GAS_PRICE })
   console.log(`REGISTRY ADDRESS: ${registryAddress}`)
 
   // TODO should prob have node process exit here rather than mash ^C

--- a/src/helpers/general.ts
+++ b/src/helpers/general.ts
@@ -41,12 +41,12 @@ export function stringToBytes(web3:Web3, str:string): string {
 // TODO i think encoded may be an array of strings?
 export async function sendSignedTransaction(web3:Web3, to:string, from:string, encoded:string, opts:ContractOptions): Promise<TransactionReceipt> {
   const rawTx = {
-    to: web3.utils.toHex(to),
-    from: web3.utils.toHex(from),
-    nonce: await web3.eth.getTransactionCount(from),
+    to: to,
+    from: from,
+    nonce: web3.utils.toHex(await web3.eth.getTransactionCount(from)),
     data: web3.utils.toHex(encoded),
-    gasLimit: opts.gas,
-    gasPrice: opts.gasPrice,
+    gasLimit: web3.utils.toHex(opts.gas),
+    gasPrice: web3.utils.toHex(opts.gasPrice),
   }
 
   let tx = new Tx(rawTx)

--- a/src/interfaces/contract.ts
+++ b/src/interfaces/contract.ts
@@ -12,6 +12,8 @@ export interface ContractOptions {
   from?:string;
   gas?:any; //gasLimit
   gasPrice?:any;
+  value?: any;
+  estimateGas?:boolean; // tells the HOC method to simply return a gas use estimate
   sign?:string; // value would be a private key
 }
 


### PR DESCRIPTION
This is what the use of `estimateGas` will look like -> same as our usage of `sign`. 

updating the contracts to remove unnecessary async/await keywords

updating specs to match new method args

more to be done, but in the other contracts, P11r and ERC20 are done here tho