### PR TITLE
update order of args in market token

### DIFF
--- a/src/contracts/market-token.ts
+++ b/src/contracts/market-token.ts
@@ -11,10 +11,10 @@ export default class extends Erc20 {
     return super.at(w3, address, MARKET_TOKEN_ABI, opts)
   }
 
-  async setPrivileged(listing:string, reserve:string, opts?:TransactOpts): Promise<Return> {
+  async setPrivileged(reserve:string, listing:string, opts?:TransactOpts): Promise<Return> {
     const deployed = this.requireDeployed()
     let assigned = this.assignTransactOpts({gas: this.getGas('setPrivileged')}, opts)
-    return [await deployed.methods.setPrivileged(listing, reserve), assigned]
+    return [await deployed.methods.setPrivileged(reserve, listing), assigned]
   }
 
   async getPrivileged(opts?:TransactOpts): Promise<Return> {


### PR DESCRIPTION
there were a few of these lingering around here and in the .py repo (fixed em all now i think)

rule of thumb is that we try to use `deploy order` in all instances where we are listing out contracts for whatever reason

i.e

`ethertoken, markettoken, voting, parameterizer, reserve, datatrust, listing`